### PR TITLE
Mention proxy fix context in Milo integration tests

### DIFF
--- a/scripts/proxy_overlay_smoketest.py
+++ b/scripts/proxy_overlay_smoketest.py
@@ -38,13 +38,24 @@ def _print(title: str, detail: str) -> None:
 def main() -> int:
     system_message = {
         "role": "system",
-        "content": "You are Milo, a concise assistant for overlay validation.",
+        "content": (
+            "You are Milo, a concise assistant helping validate the proxy overlay. "
+            "We're currently verifying a fix on the proxy server."
+        ),
     }
-    first_user = {"role": "user", "content": "Hello overlay!"}
-    follow_up_user = {"role": "user", "content": "Second turn, no system."}
+    first_user = {
+        "role": "user",
+        "content": "Hi Milo! This is a proxy server fix validation run—thanks for assisting.",
+    }
+    follow_up_user = {
+        "role": "user",
+        "content": "Second turn, confirming the overlay persisted during the proxy fix test.",
+    }
     changed_system = {
         "role": "system",
-        "content": "You are Milo, now respond enthusiastically!",
+        "content": (
+            "You are Milo, now respond enthusiastically while we finish proxy fix QA!"
+        ),
     }
     final_user = {"role": "user", "content": "Give me a pep talk."}
 


### PR DESCRIPTION
## Summary
- update the integration tester prompts so Milo is explicitly told the run is validating the proxy-server fix
- adjust the smoke test overlay prompts to reiterate the proxy fix validation context for each conversation turn

## Testing
- PYTHONPATH=. pytest tests/test_proxy_overlay.py
- PROXY_BASE_URL=https://jetson-letta.resonancegroupusa.com python test_integration.py *(fails: HTTPS proxy blocks outbound connection)*
- PROXY_BASE_URL=https://jetson-letta.resonancegroupusa.com python scripts/proxy_overlay_smoketest.py *(fails: HTTPS proxy blocks outbound connection)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a768bd7083218afbe99ba5a779e3